### PR TITLE
Fix : Test pg_escape and pg_unescape exist before executing them

### DIFF
--- a/lib/Tools/DbHelper.php
+++ b/lib/Tools/DbHelper.php
@@ -132,7 +132,12 @@ class DbHelper
     public function getExtra($data)
     {
         if ($this->getDBType() == "pgsql" && is_resource($data)) {
-            $extra = pg_unescape_bytea(stream_get_contents($data));
+            if (function_exists("pg_unescape_bytea")) {
+                $extra = pg_unescape_bytea(stream_get_contents($data));
+            }
+            else {
+                $extra = stream_get_contents($data);
+            }
             return unserialize($extra);
         }
         return unserialize($data);

--- a/lib/Tools/YoutubeHelper.php
+++ b/lib/Tools/YoutubeHelper.php
@@ -65,7 +65,9 @@ class YoutubeHelper
         if ($file) {
             $extra = serialize($extra);
             if($this->dbconn->getDBType() == "pgsql"){
-                $extra = pg_escape_bytea($extra);
+                if (function_exists("pg_escape_bytea")) {
+                    $extra = pg_escape_bytea($extra);
+                }
             }
             $data = [
                 'uid' => $this->user,


### PR DESCRIPTION
These where added on the commit : https://github.com/shiningw/ncdownloader/commit/2ec569e2b562283956b5a182775abcedc6e3380f

But was broking my ncdownloader because it was not finding the commands. Added a simple test to unbroke it at least. Will maybe need to check why these cmds are not found.