### PR TITLE
Fix: the metadata add create a copy stream error bc of ffmpeg

### DIFF
--- a/lib/Tools/Youtube.php
+++ b/lib/Tools/Youtube.php
@@ -68,8 +68,8 @@ class Youtube
     {
         if (Helper::ffmpegInstalled()) {
             $this->addOption('--prefer-ffmpeg');
-            $this->addOption('--add-metadata');
-            $this->setOption('--metadata-from-title', "%(artist)s-%(title).64s");
+            // $this->addOption('--add-metadata');
+            // $this->setOption('--metadata-from-title', "%(artist)s-%(title).64s");
             $this->addOption('--extract-audio');
         } else {
             $this->audioFormat = "m4a";


### PR DESCRIPTION
Simply disable the add metadata. This was broken with my ncdownloader installation creating this kind of error :

```bash
ERROR:   Stream #0:0 -> #0:0 (copy)
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/youtube_dl/YoutubeDL.py", line 2115, in post_process
    files_to_delete, info = pp.run(info)
  File "/usr/lib/python3/dist-packages/youtube_dl/postprocessor/ffmpeg.py", line 509, in run
    self.run_ffmpeg_multiple_files(in_filenames, temp_filename, options)
  File "/usr/lib/python3/dist-packages/youtube_dl/postprocessor/ffmpeg.py", line 235, in run_ffmpeg_multiple_files
    raise FFmpegPostProcessorError(msg)
youtube_dl.postprocessor.ffmpeg.FFmpegPostProcessorError:   Stream #0:0 -> #0:0 (copy)
```

With this error, the file is still downloaded, but there is a temp file that is created and useless.