### PR TITLE
[YoutubeDL] Restore `wait-for-video` yt-dlp option

### DIFF
--- a/lib/Ytdl/Options.php
+++ b/lib/Ytdl/Options.php
@@ -26,6 +26,7 @@ class Options
             'no-flat-playlist' => 'the videos of a playlist',
             'live-from-start' => 'livestreams from the start.',
             'no-live-from-start' => 'livestreams from the current time',
+            'wait-for-video' => 'wait for scheduled streams',
             'no-wait-for-video' => 'not wait for scheduled streams (default)',
             'mark-watched' => 'videos watched (even with --simulate)',
             'no-mark-watched' => 'not mark videos watched (default)',

--- a/src/utils/ytdlOptions.js
+++ b/src/utils/ytdlOptions.js
@@ -14,6 +14,7 @@ const options = {
     "no-flat-playlist": "the videos of a playlist",
     "live-from-start": "livestreams from the start.",
     "no-live-from-start": "livestreams from the current time",
+    "wait-for-video": "wait for scheduled streams",
     "no-wait-for-video": "not wait for scheduled streams (default)",
     "mark-watched": "videos watched (even with --simulate)",
     "no-mark-watched": "not mark videos watched (default)",


### PR DESCRIPTION
Fix https://github.com/shiningw/ncdownloader/issues/125 regression.