### PR TITLE
Fix issue 136: Download music by "Search Music" error 

### DIFF
--- a/lib/Search/Sites/sliderkz.php
+++ b/lib/Search/Sites/sliderkz.php
@@ -36,8 +36,8 @@ class sliderkz extends searchBase implements searchInterface
     }
     protected function getDownloadUrl(array $item): string
     {
-        extract($item);
-        return sprintf("https://slider.kz/download/%s/%s/%s/%s.mp3?extra=null", $id, $duration, $url, urlencode($tit_art));
+            extract($item);
+            return sprintf("https://slider.kz/%s/%s/%s/%s.mp3?extra=null",$id,$duration, $durl, urlencode($tit_art));
     }
 
     private function transformResp($data): array


### PR DESCRIPTION
Describe the bug
Music can download but size is 0

To Reproduce
Steps to reproduce the behavior:

Go to 'Search Torrents'
Change to 'MUSIC' search
Click 'Search',then download some music.
See error
Expected behavior
Music can be download and can play normally

Desktop (please complete the following information):

Any device
Smartphone (please complete the following information):

Any device
How to fix
Goto file: /apps/ncdownloader/lib/Search/Sites/sliderkz.php

Fix :
protected function getDownloadUrl(array $item): string
{
        extract($item);
        return sprintf("https://slider.kz/%s/%s/%s/%s.mp3?extra=null",$id,$duration, $durl, urlencode($tit_art));
    }