### PR TITLE
Fix get the real path of the file in the filesystem

### DIFF
--- a/lib/Tools/Helper.php
+++ b/lib/Tools/Helper.php
@@ -401,7 +401,7 @@ class Helper
         if (self::getUID()) {
             OC_Util::setupFS();
             //get the real path of the file in the filesystem
-            return \OC\Files\Filesystem::getLocalFile($path);
+            return \OC_User::getHome(\OC_User::getUser()) . '/files' . $path;
         }
         return "";
     }


### PR DESCRIPTION
For the NC >=  27.1, after update getLocalFolder start returning tmp sub-folder out of the user context