### PR TITLE
Fix division by zero in Aria2Controller.php

### DIFF
--- a/lib/Controller/Aria2Controller.php
+++ b/lib/Controller/Aria2Controller.php
@@ -207,7 +207,7 @@ class Aria2Controller extends Controller
             $folderLink = $this->urlGenerator->linkToRoute('files.view.index', $params);
             //$peers = ($this->getPeers($info['gid']));
             $completed = Helper::formatBytes($value['completedLength']);
-            $percentage = $value['completedLength'] ? 100 * ($value['completedLength'] / $value['totalLength']) : 0;
+            $percentage = $value['completedLength'] && $value['totalLength'] != 0 ? 100 * ($value['completedLength'] / $value['totalLength']) : 0;
             $completed = Helper::formatBytes($value['completedLength']);
 
             $total = Helper::formatBytes($value['totalLength']);


### PR DESCRIPTION
This fixes a division by zero that occurs in `Aria2Controller.php` when the total length is 0 (eg. aria2 is unaware of the total length, because there is no `Content-Length` header)

Fixes #169

See #169 for more info.