### PR TITLE
fix(Helper): Correct typo in month pluralization key

### DIFF
--- a/lib/Tools/Helper.php
+++ b/lib/Tools/Helper.php
@@ -243,7 +243,7 @@ class Helper
     {
         $units = array(
             '1 year|years' => 31536000,
-            '1 monthmonths' => 2592000,
+            '1 month|months' => 2592000,
             '1 week|weeks' => 604800,
             '1 day|days' => 86400,
             '1 hour|hours' => 3600,


### PR DESCRIPTION
The unit key for months was written as '1 monthmonths' instead of '1 month|months'.